### PR TITLE
chore: update launch-workflows to 0.14.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,25 @@
 version: 2
+
+multi-ecosystem-groups:
+  module:
+    schedule:
+      interval: "weekly"
+  workflows:
+    schedule:
+      interval: "weekly"
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
-    schedule:
-      interval: "weekly"
+    multi-ecosystem-group: "workflows"
+    patterns: ["*"]
+
   - package-ecosystem: "gomod"
     directory: "/"
-    schedule:
-      interval: "weekly"
+    multi-ecosystem-group: "module"
+    patterns: ["*"]
+
   - package-ecosystem: "terraform"
     directory: "/"
-    schedule:
-      interval: "weekly"
+    multi-ecosystem-group: "module"
+    patterns: ["*"]

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -25,10 +25,10 @@ categories:
 autolabeler:
   - label: "major"
     branch:
-      - '/(patch|bug|fix|feature|chore)!\/.+/'
+      - '/(patch|bug|fix|feature|feat|chore)!\/.+/'
   - label: "minor"
     branch:
-      - '/feature\/.+/'
+      - '/(feature|feat)\/.+/'
   - label: "patch"
     branch:
       - '/(patch|bug|fix|chore)\/.+/'

--- a/.github/workflows/pull-request-label.yml
+++ b/.github/workflows/pull-request-label.yml
@@ -11,5 +11,5 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-pr-label-by-branch.yml@0.10.0
+    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-pr-label-by-branch.yml@0.14.2
     secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/pull-request-terraform-check-azure.yml
+++ b/.github/workflows/pull-request-terraform-check-azure.yml
@@ -2,8 +2,8 @@ name: Check Azure Terraform Code
 
 on:
   pull_request:
-    types: [ opened, reopened, synchronize, ready_for_review ]
-    branches: [ main ]
+    types: [opened, reopened, synchronize, ready_for_review]
+    branches: [main]
 
 permissions:
   id-token: write
@@ -15,5 +15,5 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-terraform-check-azure.yml@0.10.0
+    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-terraform-check-azure.yml@0.14.2
     secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -14,5 +14,5 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-release-on-merge.yml@0.10.0
+    uses: launchbynttdata/launch-workflows/.github/workflows/reusable-release-on-merge.yml@0.14.2
     secrets: inherit # pragma: allowlist secret

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,8 +1,9 @@
 conftest 0.56.0
 golang 1.24.2
-golangci-lint 2.2.1
+golangci-lint 2.10.1
 pre-commit 4.2.0
 regula 3.2.1 # https://github.com/launchbynttdata/asdf-regula
 terraform 1.10.3
 terraform-docs 0.20.0
+terragrunt 0.77.22
 tflint 0.57.0


### PR DESCRIPTION
## Summary
- Updated `launch-workflows` reusable workflows at version `0.14.2`
- Added/updated `release-drafter.yml` and `dependabot.yml`

## Files changed
- `M  .github/dependabot.yml`
- `M  .github/release-drafter.yml`
- `M  .github/workflows/pull-request-label.yml`
- `R  .github/workflows/pull-request-terraform-check.yml -> .github/workflows/pull-request-terraform-check-azure.yml`
- `M  .github/workflows/release-publish.yml`
- `M  .tool-versions`

---
Generated by `sync_workflows.py` from [launch-workflows](https://github.com/launchbynttdata/launch-workflows)
